### PR TITLE
Consider edge detect reset as rising edge

### DIFF
--- a/G25_root/usr/local/door_access/edge_detect.py
+++ b/G25_root/usr/local/door_access/edge_detect.py
@@ -30,7 +30,7 @@ class Edge_detect(threading.Thread):
 		with self.mutex:
 			self.edgecount=0
 			self.lastwidth=0
-			self.lasttime=0
+			self.lasttime=time.time()
 
 	def run(self):
 		while not self.abort:


### PR DESCRIPTION
Pulse length detection had problems when there was no rising edge. set time of last rising edge to reset time on reset to get always plausible values